### PR TITLE
ArcFaceのバイリニアサンプリングの計算式を修正

### DIFF
--- a/Assets/AXIP/AILIA-MODELS/FaceIdentification/AiliaFeatureExtractorSample.cs
+++ b/Assets/AXIP/AILIA-MODELS/FaceIdentification/AiliaFeatureExtractorSample.cs
@@ -307,7 +307,7 @@ namespace ailiaSDK
 			int y2 = (int)fy;
 			float xa = 1.0f - (fx - x2);
 			float xb = 1.0f - xa;
-			float ya = 1.0f - (fx - x2);
+			float ya = 1.0f - (fy - y2);
 			float yb = 1.0f - ya;
 			Color32 c1 = face[y2 * w + x2];
 			Color32 c2 = (x2+1 < w) ? face[y2 * w + x2 + 1] : c1;


### PR DESCRIPTION
y方向の小数座標を計算する際にx方向の小数座標を使用してしまっている問題を修正。
縮小方向のサンプリングへの影響は軽微だが、拡大方向にサンププリングした場合に影響がある。