### PR TITLE
BlazeFaceのサンプルで非正方形に対応、Atan2計算でアスペクト比を考慮

### DIFF
--- a/Assets/AXIP/AILIA-MODELS/FaceDetection/AiliaFaceDetectorsSample.cs
+++ b/Assets/AXIP/AILIA-MODELS/FaceDetection/AiliaFaceDetectorsSample.cs
@@ -34,6 +34,8 @@ namespace ailiaSDK {
 		private int camera_id = 0;
 		[SerializeField]
 		private bool debug = false;
+		[SerializeField]
+		private bool is_square = true;
 
 		//TestImage
 		public Texture2D image = null;
@@ -160,7 +162,7 @@ namespace ailiaSDK {
 		{
 			SetUIProperties();
 			CreateAiliaDetector(ailiaModelType);
-			ailia_camera.CreateCamera(camera_id);
+			ailia_camera.CreateCamera(camera_id, is_square);
 		}
 
 		// Update is called once per frame
@@ -195,6 +197,13 @@ namespace ailiaSDK {
 			{
 				preview_texture = new Texture2D(tex_width, tex_height);
 				raw_image.texture = preview_texture;
+				if (!is_square){
+					Vector2 size = raw_image.rectTransform.sizeDelta;
+					float ratio = tex_width / (float)tex_height;
+					raw_image.rectTransform.sizeDelta = new Vector2(ratio * size.y, size.y);
+					size = line_panel.GetComponent<RectTransform>().sizeDelta;
+					line_panel.GetComponent<RectTransform>().sizeDelta = new Vector2(ratio * size.y, size.y);
+				}
 			}
 
 			long detection_time = 0;

--- a/Assets/AXIP/AILIA-MODELS/FaceDetection/AiliaFaceMesh.cs
+++ b/Assets/AXIP/AILIA-MODELS/FaceDetection/AiliaFaceMesh.cs
@@ -46,8 +46,8 @@ namespace ailiaSDK
 				int fy = (int)(face.center.y * tex_height);
 				const int RIGHT_EYE=0;
 				const int LEFT_EYE=1;
-				float theta_x = (float)(face.keypoints[LEFT_EYE].x - face.keypoints[RIGHT_EYE].x);
-				float theta_y = (float)(face.keypoints[LEFT_EYE].y - face.keypoints[RIGHT_EYE].y);
+				float theta_x = (float)(face.keypoints[LEFT_EYE].x - face.keypoints[RIGHT_EYE].x) * tex_width;
+				float theta_y = (float)(face.keypoints[LEFT_EYE].y - face.keypoints[RIGHT_EYE].y) * tex_height;
 				float theta = (float)System.Math.Atan2(theta_y,theta_x);
 
 				//extract data


### PR DESCRIPTION
BlazeFaceのサンプルで非正方形画像の入力に対応しました。

blazefaceとfacemeshはアスペクトレシオ1:1の画像に対して処理します。
下記のコードでは、入力画像の水平解像度を128pxに揃え、高さ方向にパディングします。
https://github.com/axinc-ai/ailia-csharp/blob/main/ailia-csharp/ailia-csharp/facemesh/AiliaBlazeface.cs

出力のFaceInfoは、パディング前の空間で0-1の値に正規化した座標系を扱います。
パディング分を削除するため、AI出力の値に、aspectを乗算しています。

この値の空間は、ピクセル空間ではないため、そのままatan2を計算すると、誤差が生じます。
そのため、tex_widthとtex_heightを乗算した上で、thetaを計算した方が、正確な値となります。