### PR TITLE
Fix retinaface input image channel order

### DIFF
--- a/Assets/AXIP/AILIA-MODELS/FaceDetection/AiliaRetinaface.cs
+++ b/Assets/AXIP/AILIA-MODELS/FaceDetection/AiliaRetinaface.cs
@@ -63,9 +63,9 @@ namespace ailiaSDK
 			{
 				for (int x = 0; x < w; x++)
 				{
-					data[(y * w + x) + 0 * w * h] = (float)(((camera[(tex_height - 1 - y) * tex_width + x].r) - 123.0f));
+					data[(y * w + x) + 2 * w * h] = (float)(((camera[(tex_height - 1 - y) * tex_width + x].r) - 123.0f));
                     data[(y * w + x) + 1 * w * h] = (float)(((camera[(tex_height - 1 - y) * tex_width + x].g) - 117.0f));
-                    data[(y * w + x) + 2 * w * h] = (float)(((camera[(tex_height - 1 - y) * tex_width + x].b) - 104.0f));
+                    data[(y * w + x) + 0 * w * h] = (float)(((camera[(tex_height - 1 - y) * tex_width + x].b) - 104.0f));
 				}
 			}
 

--- a/Assets/AXIP/AILIA-MODELS/FaceDetection/AiliaRetinaface.cs
+++ b/Assets/AXIP/AILIA-MODELS/FaceDetection/AiliaRetinaface.cs
@@ -64,8 +64,8 @@ namespace ailiaSDK
 				for (int x = 0; x < w; x++)
 				{
 					data[(y * w + x) + 2 * w * h] = (float)(((camera[(tex_height - 1 - y) * tex_width + x].r) - 123.0f));
-                    data[(y * w + x) + 1 * w * h] = (float)(((camera[(tex_height - 1 - y) * tex_width + x].g) - 117.0f));
-                    data[(y * w + x) + 0 * w * h] = (float)(((camera[(tex_height - 1 - y) * tex_width + x].b) - 104.0f));
+					data[(y * w + x) + 1 * w * h] = (float)(((camera[(tex_height - 1 - y) * tex_width + x].g) - 117.0f));
+					data[(y * w + x) + 0 * w * h] = (float)(((camera[(tex_height - 1 - y) * tex_width + x].b) - 104.0f));
 				}
 			}
 


### PR DESCRIPTION
Pytorch版は、imreadしたBGR順の画像に対して処理を行っている。
https://github.com/biubug6/Pytorch_Retinaface/blob/master/detect.py
現状のUnity版はRGB順の画像に対して処理をしているので修正する。